### PR TITLE
Upgrade to PhantomJS 1.9.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,15 +36,15 @@
     "test": "mocha --compilers coffee:coffee-script test/mocha-phantomjs.coffee -t 20000 -R spec"
   },
   "peerDependencies": {
-    "phantomjs": "1.9.8"
+    "phantomjs": "1.9.20"
   },
   "dependencies": {
     "mocha": "~1.20.1",
     "commander": "~2.0.0",
-    "phantomjs": "1.9.8"
+    "phantomjs": "1.9.20"
   },
   "devDependencies": {
-    "phantomjs": "1.9.8",
+    "phantomjs": "1.9.20",
     "chai": "1.8.x",
     "coffee-script": "1.6.x",
     "requirejs": "2.1.x"

--- a/package.json
+++ b/package.json
@@ -36,15 +36,15 @@
     "test": "mocha --compilers coffee:coffee-script test/mocha-phantomjs.coffee -t 20000 -R spec"
   },
   "peerDependencies": {
-    "phantomjs": "1.9.7-15"
+    "phantomjs": "1.9.8"
   },
   "dependencies": {
     "mocha": "~1.20.1",
     "commander": "~2.0.0",
-    "phantomjs": "1.9.7-15"
+    "phantomjs": "1.9.8"
   },
   "devDependencies": {
-    "phantomjs": "1.9.7-15",
+    "phantomjs": "1.9.8",
     "chai": "1.8.x",
     "coffee-script": "1.6.x",
     "requirejs": "2.1.x"


### PR DESCRIPTION
Upgrades this Mobify fork to point to phantomjs `1.9.20` (which installs version `1.9.8` of the phantomjs binary). Previous versions of phantomjs referenced a phantomjs binary that isn't already on CircleCI causing the `npm install` process to take longer as it has to download a different phantomjs binary. 

Example: https://circleci.com/gh/mobify/extra-mobile/1317

```
/
> phantomjs@1.9.7-15 install /home/ubuntu/extra-mobile/web/node_modules/adaptivejs/node_modules/grunt-mocha-phantomjs/node_modules/phantomjs
> node install.js

PhantomJS detected, but wrong version 1.9.8 @ /usr/local/bin/phantomjs.
Downloading https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2
Saving to /tmp/phantomjs/phantomjs-1.9.7-linux-x86_64.tar.bz2
Receiving...
/
Received 12852K total.
Extracting tar contents (via spawned process)
Copying extracted folder /tmp/phantomjs/phantomjs-1.9.7-linux-x86_64.tar.bz2-extract-1461229894845/phantomjs-1.9.7-linux-x86_64 -> /home/ubuntu/extra-mobile/web/node_modules/adaptivejs/node_modules/grunt-mocha-phantomjs/node_modules/phantomjs/lib/phantom
Writing location.js file
Done. Phantomjs binary available at /home/ubuntu/extra-mobile/web/node_modules/adaptivejs/node_modules/grunt-mocha-phantomjs/node_modules/phantomjs/lib/phantom/bin/phantomjs
```

Tested on: https://github.com/mobify/extra-mobile/pull/111
